### PR TITLE
Array test

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ It can be used to convert colors from and to RGB, HSV, HSL and CMYK.
 ## Tutorial
 
 ### Values
-Not necessarily be integers. All real numbers are accepted (though there should have no negative values).
+Not necessarily be integers. All real numbers are accepted ^((though there should have no negative values)).
 
 #### RGB
-RGB values are input as 0<=X<=255.
+RGB values are decimal values (0<=X<=255).
 example: maroon as `128,0,0`
 
 #### HSV, HSL
-Both with hue between 0 to 360 as degrees. Saturation, Value or Lightness values are percents.
+Both with hue between 0 to 360 as degrees. Saturation, variance or lightness values are percents.
 example: maroon as `(HSV)0,100,25` `(HSL)0,100,50`
 
 ### CMYK

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ example: maroon as `128,0,0`
 Both with hue between 0 to 360 as degrees. Saturation, variance or lightness values are percents.
 example: maroon as `(HSV)0,100,25` `(HSL)0,100,50`
 
-### CMYK
+#### CMYK
 CMYK values are all percents.
 ecample: maroon as `0,100,100,50`
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It can be used to convert colors from and to RGB, HSV, HSL and CMYK.
 ## Tutorial
 
 ### Values
-Not necessarily be integers. All real numbers are accepted ^((though there should have no negative values)).
+Not necessarily be integers. All real numbers are accepted (though there should have no negative values).
 
 #### RGB
 RGB values are decimal values (0<=X<=255).

--- a/colorswitch.php
+++ b/colorswitch.php
@@ -74,26 +74,22 @@ class ColorSwitch
 
     public function outputHSV()
     {
-        $red = $this->sourceRGB[0];
-        $green = $this->sourceRGB[1];
-        $blue = $this->sourceRGB[2];
-
-        $max = max($red, $green, $blue);
-        $min = min($red, $green, $blue);
+        $max = max($this->sourceRGB);
+        $min = min($this->sourceRGB);
         $chroma = $max - $min;
 
         switch ($max) {
             case 0:
                 $hue = 0;
                 break;
-            case $red:
-                $hue = ($green - $blue) / $chroma;
+            case $this->sourceRGB[0]:
+                $hue = ($this->sourceRGB[1] - $this->sourceRGB[2]) / $chroma;
                 break;
-            case $green:
-                $hue = ($blue - $red) / $chroma + 2;
+            case $this->sourceRGB[1]:
+                $hue = ($this->sourceRGB[2] - $this->sourceRGB[0]) / $chroma + 2;
                 break;
-            case $blue:
-                $hue = ($red - $green) / $chroma + 4;
+            case $this->sourceRGB[2]:
+                $hue = ($this->sourceRGB[0] - $this->sourceRGB[1]) / $chroma + 4;
                 break;
             default:
                 $hue = 0;
@@ -101,32 +97,27 @@ class ColorSwitch
 
         $hue = fmod(($hue * 60 + 360) , 360);  // ensures it is positive
         $saturation = ($max == 0) ? 0 : ($chroma / $max * 100);
-        $variance = $max * 100;
-        $this->result = array($hue, $saturation, $variance);
+        $this->result = array($hue, $saturation, $max * 100);
     }
 
     public function outputHSL()
     {
-        $red = $this->sourceRGB[0];
-        $green = $this->sourceRGB[1];
-        $blue = $this->sourceRGB[2];
-
-        $max = max($red, $green, $blue);
-        $min = min($red, $green, $blue);
+        $max = max($this->sourceRGB);
+        $min = min($this->sourceRGB);
         $chroma = $max - $min;
 
         switch ($max) {
             case 0:
                 $hue = 0;
                 break;
-            case $red:
-                $hue = ($green - $blue) / $chroma;
+            case $this->sourceRGB[0]:
+                $hue = ($this->sourceRGB[1] - $this->sourceRGB[2]) / $chroma;
                 break;
-            case $green:
-                $hue = ($blue - $red) / $chroma + 2;
+            case $this->sourceRGB[1]:
+                $hue = ($this->sourceRGB[2] - $this->sourceRGB[0]) / $chroma + 2;
                 break;
-            case $blue:
-                $hue = ($red - $green) / $chroma + 4;
+            case $this->sourceRGB[2]:
+                $hue = ($this->sourceRGB[0] - $this->sourceRGB[1]) / $chroma + 4;
                 break;
             default:
                 $hue = 0;
@@ -140,16 +131,12 @@ class ColorSwitch
 
     public function outputCMYK()
     {
-        $red = $this->sourceRGB[0];
-        $green = $this->sourceRGB[1];
-        $blue = $this->sourceRGB[2];
-
-        $max = max($red, $green, $blue);
+        $max = max($this->sourceRGB);
         $K = 1 - $max;
         if ($K < 1) {
-            $C = (1 - $red - $K) / (1 - $K);
-            $M = (1 - $green - $K) / (1 - $K);
-            $Y = (1 - $blue - $K) / (1 - $K);
+            $C = (1 - $this->sourceRGB[0] - $K) / (1 - $K);
+            $M = (1 - $this->sourceRGB[1] - $K) / (1 - $K);
+            $Y = (1 - $this->sourceRGB[2] - $K) / (1 - $K);
         } else {
             $C = $M = $Y = 0;
         }

--- a/colorswitch.php
+++ b/colorswitch.php
@@ -32,7 +32,13 @@ class ColorSwitch
         }
 
         $m = ($input[2] / 100) - ($C / 2);
-        $this->sourceRGB = array_map( function($val) { return $val + m; }, $this->sourceRGB);
+        $this->sourceRGB = array_map( 
+            function ($val) use ($m)
+            { 
+                return $val + $m; 
+            },
+            $this->sourceRGB
+        );
     }
 
     public function inputHSV($input)
@@ -56,20 +62,30 @@ class ColorSwitch
         }
 
         $m = $input[2] / 100 - $C;
-        $this->sourceRGB = array_map( function($val) { return $val + m; }, $this->sourceRGB);
+        $this->sourceRGB = array_map( 
+            function ($val) use ($m)
+            { 
+                return $val + $m; 
+            },
+            $this->sourceRGB
+        );
     }
 
     public function inputCMYK($input)
     {
-        $K = $input[3] * 100;
+        $K = $input[3] / 100;
 
         // make CMYK into CMY of actual value (from percents)
         $CMY = $input;
-        \unset($CMY[3]); // remove the excess K from CMYK
-        $CMY = array_map( function($val) { return $val / 100; }, $CMY);
+        unset($CMY[3]); // remove the excess K from CMYK
 
-        $this->sourceRGB = $CMY;
-        $this->sourceRGB = array_map( function($val) { return (1 - $val) * (1 - $K); }, $this->sourceRGB);
+        $this->sourceRGB = array_map( 
+            function($val) use ($K)
+            { 
+                return (1 - $val / 100) * (1 - $K);
+            }, 
+            $CMY
+        );
     }
 
     public function outputHSV()

--- a/colorswitch.php
+++ b/colorswitch.php
@@ -2,16 +2,13 @@
 
 class ColorSwitch
 {
+    // RGB color space in 0<=X<=1
+    var $sourceRGB;
     var $result;
-    var $red; 
-    var $green;
-    var $blue;
 
     public function inputRGB($input)
     {
-        $this->red = $input[0] / 255;
-        $this->green = $input[1] / 255;
-        $this->blue = $input[2] / 255;
+        $this->sourceRGB = array_map( function($val) { return $val / 255; }, $input);
     }
 
     public function inputHSL($input)
@@ -21,35 +18,21 @@ class ColorSwitch
         $X = $C * (1 - abs(fmod($hue, 2) - 1));
 
         if ($hue <= 1) {
-            $this->red = $C;
-            $this->green = $X;
-            $this->blue = 0;
+            $this->sourceRGB = array($C, $X, 0);
         } elseif ($hue <= 2) {
-            $this->red = $X;
-            $this->green = $C;
-            $this->blue = 0;
+            $this->sourceRGB = array($X, $C, 0);
         } elseif ($hue <= 3) {
-            $this->red = 0;
-            $this->green = $C;
-            $this->blue = $X;
+            $this->sourceRGB = array(0, $C, $X);
         } elseif ($hue <= 4) {
-            $this->red = 0;
-            $this->green = $X;
-            $this->blue = $C;
+            $this->sourceRGB = array(0, $X, $C);
         } elseif ($hue <= 5) {
-            $this->red = $X;
-            $this->green = 0;
-            $this->blue = $C;
+            $this->sourceRGB = array($X, 0, $C);
         } elseif ($hue <= 6) {
-            $this->red = $C;
-            $this->green = 0;
-            $this->blue = $X;
+            $this->sourceRGB = array($C, 0, $X);
         }
 
         $m = ($input[2] / 100) - ($C / 2);
-        $this->red = $this->red + $m;
-        $this->green = $this->green + $m;
-        $this->blue = $this->blue + $m;
+        $this->sourceRGB = array_map( function($val) { return $val + m; }, $this->sourceRGB);
     }
 
     public function inputHSV($input)
@@ -59,49 +42,41 @@ class ColorSwitch
         $X = $C * (1 - abs(fmod($hue, 2) - 1));
 
         if ($hue <= 1) {
-            $this->red = $C;
-            $this->green = $X;
-            $this->blue = 0;
+            $this->sourceRGB = array($C, $X, 0);
         } elseif ($hue <= 2) {
-            $this->red = $X;
-            $this->green = $C;
-            $this->blue = 0;
+            $this->sourceRGB = array($X, $C, 0);
         } elseif ($hue <= 3) {
-            $this->red = 0;
-            $this->green = $C;
-            $this->blue = $X;
+            $this->sourceRGB = array(0, $C, $X);
         } elseif ($hue <= 4) {
-            $this->red = 0;
-            $this->green = $X;
-            $this->blue = $C;
+            $this->sourceRGB = array(0, $X, $C);
         } elseif ($hue <= 5) {
-            $this->red = $X;
-            $this->green = 0;
-            $this->blue = $C;
+            $this->sourceRGB = array($X, 0, $C);
         } elseif ($hue <= 6) {
-            $this->red = $C;
-            $this->green = 0;
-            $this->blue = $X;
+            $this->sourceRGB = array($C, 0, $X);
         }
 
         $m = $input[2] / 100 - $C;
-        $this->red = $this->red + $m;
-        $this->green = $this->green + $m;
-        $this->blue = $this->blue + $m;
+        $this->sourceRGB = array_map( function($val) { return $val + m; }, $this->sourceRGB);
     }
 
     public function inputCMYK($input)
     {
-        $this->red = (100 - $input[0]) * (100 - $input[3]) / 10000;
-        $this->green = (100 - $input[1]) * (100 - $input[3]) / 10000;
-        $this->blue = (100 - $input[2]) * (100 - $input[3]) / 10000;
+        $K = $input[3] * 100;
+
+        // make CMYK into CMY of actual value (from percents)
+        $CMY = $input;
+        \unset($CMY[3]); // remove the excess K from CMYK
+        $CMY = array_map( function($val) { return $val / 100; }, $CMY);
+
+        $this->sourceRGB = $CMY;
+        $this->sourceRGB = array_map( function($val) { return (1 - $val) * (1 - $K); }, $this->sourceRGB);
     }
 
     public function outputHSV()
     {
-        $red = $this->red;
-        $green = $this->green;
-        $blue = $this->blue;
+        $red = $this->sourceRGB[0];
+        $green = $this->sourceRGB[1];
+        $blue = $this->sourceRGB[2];
 
         $max = max($red, $green, $blue);
         $min = min($red, $green, $blue);
@@ -124,7 +99,7 @@ class ColorSwitch
                 $hue = 0;
         }
 
-        $hue = ($hue * 60 + 360) % 360;  // ensures it is positive
+        $hue = fmod(($hue * 60 + 360) , 360);  // ensures it is positive
         $saturation = ($max == 0) ? 0 : ($chroma / $max * 100);
         $variance = $max * 100;
         $this->result = array($hue, $saturation, $variance);
@@ -132,9 +107,9 @@ class ColorSwitch
 
     public function outputHSL()
     {
-        $red = $this->red;
-        $green = $this->green;
-        $blue = $this->blue;
+        $red = $this->sourceRGB[0];
+        $green = $this->sourceRGB[1];
+        $blue = $this->sourceRGB[2];
 
         $max = max($red, $green, $blue);
         $min = min($red, $green, $blue);
@@ -157,7 +132,7 @@ class ColorSwitch
                 $hue = 0;
         }
 
-        $hue = ($hue * 60 + 360) % 360;  // ensures it is positive
+        $hue = fmod(($hue * 60 + 360) , 360);  // ensures it is positive
         $lightness = ($max + $min) * 50;
         $saturation = ($chroma === 0) ? 0 : ($chroma / (1 - abs($lightness * 0.02 - 1)) * 100);
         $this->result = array($hue, $saturation, $lightness);
@@ -165,9 +140,9 @@ class ColorSwitch
 
     public function outputCMYK()
     {
-        $red = $this->red;
-        $green = $this->green;
-        $blue = $this->blue;
+        $red = $this->sourceRGB[0];
+        $green = $this->sourceRGB[1];
+        $blue = $this->sourceRGB[2];
 
         $max = max($red, $green, $blue);
         $K = 1 - $max;
@@ -183,7 +158,7 @@ class ColorSwitch
 
     public function outputRGB()
     {
-        $this->result = array($this->red * 255, $this->green * 255, $this->blue * 255);
+        $this->result = array_map( function($val) { return $val * 255; }, $this->sourceRGB);
     }
 
 }


### PR DESCRIPTION
A test to use an array of RGB colors instead of three `$red`, `$green`, and `$blue` variables. Also adopted some `array_map` functions rather than assigning repeatedly.

Details:
- better CMYK to RGB algorithm representation
- reduced memory usage of `outputHSV` and `outputHSL` functions
- optimization of some lines of codes